### PR TITLE
rk3328-beikeyun dts add rockchip dmc

### DIFF
--- a/arch/arm64/boot/dts/rockchip/rk3328-beikeyun-1296mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/rk3328-beikeyun-1296mhz.dts
@@ -4,6 +4,7 @@
  */
 
 /dts-v1/;
+#include "rk3328-dram-renegade-timing.dtsi"
 #include "rk3328.dtsi"
 
 / {
@@ -123,6 +124,72 @@
 			regulator-always-on;
 		};
 	};
+
+	dfi: dfi@ff790000 {
+		reg = <0x00 0xff790000 0x00 0x400>;
+		compatible = "rockchip,rk3328-dfi";
+		rockchip,grf = <&grf>;
+		status = "disabled";
+	};
+
+	dmc: dmc {
+		compatible = "rockchip,rk3328-dmc";
+		devfreq-events = <&dfi>;
+		clocks = <&cru SCLK_DDRCLK>;
+		clock-names = "dmc_clk";
+		operating-points-v2 = <&dmc_opp_table>;
+		ddr_timing = <&ddr_timing>;
+		upthreshold = <40>;
+		downdifferential = <20>;
+		auto-min-freq = <786000>;
+		auto-freq-en = <0>;
+		#cooling-cells = <2>;
+		status = "disabled";
+
+		ddr_power_model: ddr_power_model {
+			compatible = "ddr_power_model";
+			dynamic-power-coefficient = <120>;
+			static-power-coefficient = <200>;
+			ts = <32000 4700 (-80) 2>;
+			thermal-zone = "soc-thermal";
+		};
+	};
+
+	dmc_opp_table: dmc-opp-table {
+		compatible = "operating-points-v2";
+
+		rockchip,leakage-voltage-sel = <
+			1   10    0
+			11  254   1
+		>;
+		nvmem-cells = <&logic_leakage>;
+		nvmem-cell-names = "ddr_leakage";
+
+		opp-786000000 {
+			opp-hz = /bits/ 64 <786000000>;
+			opp-microvolt = <1150000>;
+			opp-microvolt-L0 = <1150000>;
+			opp-microvolt-L1 = <1075000>;
+		};
+		opp-798000000 {
+			opp-hz = /bits/ 64 <798000000>;
+			opp-microvolt = <1150000>;
+			opp-microvolt-L0 = <1150000>;
+			opp-microvolt-L1 = <1075000>;
+		};
+		opp-840000000 {
+			opp-hz = /bits/ 64 <840000000>;
+			opp-microvolt = <1150000>;
+			opp-microvolt-L0 = <1150000>;
+			opp-microvolt-L1 = <1075000>;
+		};
+		opp-924000000 {
+			opp-hz = /bits/ 64 <924000000>;
+			opp-microvolt = <1150000>;
+			opp-microvolt-L0 = <1150000>;
+			opp-microvolt-L1 = <1075000>;
+		};
+	};
 };
 
 &analog_sound {
@@ -207,6 +274,15 @@
 
 &gpu {
 	mali-supply = <&vdd_logic>;
+};
+
+&dfi {
+	status = "okay";
+};
+
+&dmc {
+	center-supply = <&vdd_logic>;
+	status = "okay";
 };
 
 &rng {

--- a/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
+++ b/arch/arm64/boot/dts/rockchip/rk3328-dram-renegade-timing.dtsi
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2017 Fuzhou Rockchip Electronics Co., Ltd
+ *
+ * This file is dual-licensed: you can use it either under the terms
+ * of the GPL or the X11 license, at your option. Note that this dual
+ * licensing only applies to this file, and not this project as a
+ * whole.
+ *
+ *  a) This library is free software; you can redistribute it and/or
+ *     modify it under the terms of the GNU General Public License as
+ *     published by the Free Software Foundation; either version 2 of the
+ *     License, or (at your option) any later version.
+ *
+ *     This library is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU General Public License for more details.
+ *
+ * Or, alternatively,
+ *
+ *  b) Permission is hereby granted, free of charge, to any person
+ *     obtaining a copy of this software and associated documentation
+ *     files (the "Software"), to deal in the Software without
+ *     restriction, including without limitation the rights to use,
+ *     copy, modify, merge, publish, distribute, sublicense, and/or
+ *     sell copies of the Software, and to permit persons to whom the
+ *     Software is furnished to do so, subject to the following
+ *     conditions:
+ *
+ *     The above copyright notice and this permission notice shall be
+ *     included in all copies or substantial portions of the Software.
+ *
+ *     THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ *     EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ *     OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ *     NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ *     HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ *     WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *     FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ *     OTHER DEALINGS IN THE SOFTWARE.
+ */
+#include <dt-bindings/clock/rockchip-ddr.h>
+#include <dt-bindings/memory/rk3328-dram.h>
+
+/ {
+	ddr_timing: ddr_timing {
+		compatible = "rockchip,ddr-timing";
+		ddr3_speed_bin = <DDR3_DEFAULT>;
+		ddr4_speed_bin = <DDR4_DEFAULT>;
+		pd_idle = <0>;
+		sr_idle = <0>;
+		sr_mc_gate_idle = <0>;
+		srpd_lite_idle	= <0>;
+		standby_idle = <0>;
+
+		auto_pd_dis_freq = <1066>;
+		auto_sr_dis_freq = <800>;
+		ddr3_dll_dis_freq = <300>;
+		ddr4_dll_dis_freq = <625>;
+		phy_dll_dis_freq = <400>;
+
+		ddr3_odt_dis_freq = <100>;
+		phy_ddr3_odt_dis_freq = <100>;
+		ddr3_drv = <DDR3_DS_40ohm>;
+		ddr3_odt = <DDR3_ODT_120ohm>;
+		phy_ddr3_ca_drv = <PHY_DDR3_RON_RTT_34ohm>;
+		phy_ddr3_ck_drv = <PHY_DDR3_RON_RTT_45ohm>;
+		phy_ddr3_dq_drv = <PHY_DDR3_RON_RTT_34ohm>;
+		phy_ddr3_odt = <PHY_DDR3_RON_RTT_225ohm>;
+
+		lpddr3_odt_dis_freq = <666>;
+		phy_lpddr3_odt_dis_freq = <666>;
+		lpddr3_drv = <LP3_DS_40ohm>;
+		lpddr3_odt = <LP3_ODT_240ohm>;
+		phy_lpddr3_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
+		phy_lpddr3_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
+		phy_lpddr3_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
+		phy_lpddr3_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
+
+		lpddr4_odt_dis_freq = <800>;
+		phy_lpddr4_odt_dis_freq = <800>;
+		lpddr4_drv = <LP4_PDDS_60ohm>;
+		lpddr4_dq_odt = <LP4_DQ_ODT_40ohm>;
+		lpddr4_ca_odt = <LP4_CA_ODT_40ohm>;
+		phy_lpddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_40ohm>;
+		phy_lpddr4_ck_cs_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
+		phy_lpddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_80ohm>;
+		phy_lpddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_60ohm>;
+
+		ddr4_odt_dis_freq = <666>;
+		phy_ddr4_odt_dis_freq = <666>;
+		ddr4_drv = <DDR4_DS_34ohm>;
+		ddr4_odt = <DDR4_RTT_NOM_240ohm>;
+		phy_ddr4_ca_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
+		phy_ddr4_ck_drv = <PHY_DDR4_LPDDR3_RON_RTT_43ohm>;
+		phy_ddr4_dq_drv = <PHY_DDR4_LPDDR3_RON_RTT_34ohm>;
+		phy_ddr4_odt = <PHY_DDR4_LPDDR3_RON_RTT_240ohm>;
+
+		/* CA de-skew, one step is 47.8ps, range 0-15 */
+		ddr3a1_ddr4a9_de-skew = <0>;
+		ddr3a0_ddr4a10_de-skew = <0>;
+		ddr3a3_ddr4a6_de-skew = <1>;
+		ddr3a2_ddr4a4_de-skew = <1>;
+		ddr3a5_ddr4a8_de-skew = <0>;
+		ddr3a4_ddr4a5_de-skew = <2>;
+		ddr3a7_ddr4a11_de-skew = <0>;
+		ddr3a6_ddr4a7_de-skew = <2>;
+		ddr3a9_ddr4a0_de-skew = <1>;
+		ddr3a8_ddr4a13_de-skew = <0>;
+		ddr3a11_ddr4a3_de-skew = <2>;
+		ddr3a10_ddr4cs0_de-skew = <0>;
+		ddr3a13_ddr4a2_de-skew = <1>;
+		ddr3a12_ddr4ba1_de-skew = <0>;
+		ddr3a15_ddr4odt0_de-skew = <0>;
+		ddr3a14_ddr4a1_de-skew = <1>;
+		ddr3ba1_ddr4a15_de-skew = <0>;
+		ddr3ba0_ddr4bg0_de-skew = <0>;
+		ddr3ras_ddr4cke_de-skew = <0>;
+		ddr3ba2_ddr4ba0_de-skew = <1>;
+		ddr3we_ddr4bg1_de-skew = <1>;
+		ddr3cas_ddr4a12_de-skew = <0>;
+		ddr3ckn_ddr4ckn_de-skew = <5>;
+		ddr3ckp_ddr4ckp_de-skew = <5>;
+		ddr3cke_ddr4a16_de-skew = <1>;
+		ddr3odt0_ddr4a14_de-skew = <0>;
+		ddr3cs0_ddr4act_de-skew = <1>;
+		ddr3reset_ddr4reset_de-skew = <0>;
+		ddr3cs1_ddr4cs1_de-skew = <0>;
+		ddr3odt1_ddr4odt1_de-skew = <0>;
+
+		/* DATA de-skew
+		 * RX one step is 25.1ps, range 0-15
+		 * TX one step is 47.8ps, range 0-15
+		 */
+		cs0_dm0_rx_de-skew = <7>;
+		cs0_dm0_tx_de-skew = <8>;
+		cs0_dq0_rx_de-skew = <7>;
+		cs0_dq0_tx_de-skew = <8>;
+		cs0_dq1_rx_de-skew = <7>;
+		cs0_dq1_tx_de-skew = <8>;
+		cs0_dq2_rx_de-skew = <7>;
+		cs0_dq2_tx_de-skew = <8>;
+		cs0_dq3_rx_de-skew = <7>;
+		cs0_dq3_tx_de-skew = <8>;
+		cs0_dq4_rx_de-skew = <7>;
+		cs0_dq4_tx_de-skew = <8>;
+		cs0_dq5_rx_de-skew = <7>;
+		cs0_dq5_tx_de-skew = <8>;
+		cs0_dq6_rx_de-skew = <7>;
+		cs0_dq6_tx_de-skew = <8>;
+		cs0_dq7_rx_de-skew = <7>;
+		cs0_dq7_tx_de-skew = <8>;
+		cs0_dqs0_rx_de-skew = <6>;
+		cs0_dqs0p_tx_de-skew = <9>;
+		cs0_dqs0n_tx_de-skew = <9>;
+
+		cs0_dm1_rx_de-skew = <7>;
+		cs0_dm1_tx_de-skew = <7>;
+		cs0_dq8_rx_de-skew = <7>;
+		cs0_dq8_tx_de-skew = <8>;
+		cs0_dq9_rx_de-skew = <7>;
+		cs0_dq9_tx_de-skew = <7>;
+		cs0_dq10_rx_de-skew = <7>;
+		cs0_dq10_tx_de-skew = <8>;
+		cs0_dq11_rx_de-skew = <7>;
+		cs0_dq11_tx_de-skew = <7>;
+		cs0_dq12_rx_de-skew = <7>;
+		cs0_dq12_tx_de-skew = <8>;
+		cs0_dq13_rx_de-skew = <7>;
+		cs0_dq13_tx_de-skew = <7>;
+		cs0_dq14_rx_de-skew = <7>;
+		cs0_dq14_tx_de-skew = <8>;
+		cs0_dq15_rx_de-skew = <7>;
+		cs0_dq15_tx_de-skew = <7>;
+		cs0_dqs1_rx_de-skew = <7>;
+		cs0_dqs1p_tx_de-skew = <9>;
+		cs0_dqs1n_tx_de-skew = <9>;
+
+		cs0_dm2_rx_de-skew = <7>;
+		cs0_dm2_tx_de-skew = <8>;
+		cs0_dq16_rx_de-skew = <7>;
+		cs0_dq16_tx_de-skew = <8>;
+		cs0_dq17_rx_de-skew = <7>;
+		cs0_dq17_tx_de-skew = <8>;
+		cs0_dq18_rx_de-skew = <7>;
+		cs0_dq18_tx_de-skew = <8>;
+		cs0_dq19_rx_de-skew = <7>;
+		cs0_dq19_tx_de-skew = <8>;
+		cs0_dq20_rx_de-skew = <7>;
+		cs0_dq20_tx_de-skew = <8>;
+		cs0_dq21_rx_de-skew = <7>;
+		cs0_dq21_tx_de-skew = <8>;
+		cs0_dq22_rx_de-skew = <7>;
+		cs0_dq22_tx_de-skew = <8>;
+		cs0_dq23_rx_de-skew = <7>;
+		cs0_dq23_tx_de-skew = <8>;
+		cs0_dqs2_rx_de-skew = <6>;
+		cs0_dqs2p_tx_de-skew = <9>;
+		cs0_dqs2n_tx_de-skew = <9>;
+
+		cs0_dm3_rx_de-skew = <7>;
+		cs0_dm3_tx_de-skew = <7>;
+		cs0_dq24_rx_de-skew = <7>;
+		cs0_dq24_tx_de-skew = <8>;
+		cs0_dq25_rx_de-skew = <7>;
+		cs0_dq25_tx_de-skew = <7>;
+		cs0_dq26_rx_de-skew = <7>;
+		cs0_dq26_tx_de-skew = <7>;
+		cs0_dq27_rx_de-skew = <7>;
+		cs0_dq27_tx_de-skew = <7>;
+		cs0_dq28_rx_de-skew = <7>;
+		cs0_dq28_tx_de-skew = <7>;
+		cs0_dq29_rx_de-skew = <7>;
+		cs0_dq29_tx_de-skew = <7>;
+		cs0_dq30_rx_de-skew = <7>;
+		cs0_dq30_tx_de-skew = <7>;
+		cs0_dq31_rx_de-skew = <7>;
+		cs0_dq31_tx_de-skew = <7>;
+		cs0_dqs3_rx_de-skew = <7>;
+		cs0_dqs3p_tx_de-skew = <9>;
+		cs0_dqs3n_tx_de-skew = <9>;
+
+		cs1_dm0_rx_de-skew = <7>;
+		cs1_dm0_tx_de-skew = <8>;
+		cs1_dq0_rx_de-skew = <7>;
+		cs1_dq0_tx_de-skew = <8>;
+		cs1_dq1_rx_de-skew = <7>;
+		cs1_dq1_tx_de-skew = <8>;
+		cs1_dq2_rx_de-skew = <7>;
+		cs1_dq2_tx_de-skew = <8>;
+		cs1_dq3_rx_de-skew = <7>;
+		cs1_dq3_tx_de-skew = <8>;
+		cs1_dq4_rx_de-skew = <7>;
+		cs1_dq4_tx_de-skew = <8>;
+		cs1_dq5_rx_de-skew = <7>;
+		cs1_dq5_tx_de-skew = <8>;
+		cs1_dq6_rx_de-skew = <7>;
+		cs1_dq6_tx_de-skew = <8>;
+		cs1_dq7_rx_de-skew = <7>;
+		cs1_dq7_tx_de-skew = <8>;
+		cs1_dqs0_rx_de-skew = <6>;
+		cs1_dqs0p_tx_de-skew = <9>;
+		cs1_dqs0n_tx_de-skew = <9>;
+
+		cs1_dm1_rx_de-skew = <7>;
+		cs1_dm1_tx_de-skew = <7>;
+		cs1_dq8_rx_de-skew = <7>;
+		cs1_dq8_tx_de-skew = <8>;
+		cs1_dq9_rx_de-skew = <7>;
+		cs1_dq9_tx_de-skew = <7>;
+		cs1_dq10_rx_de-skew = <7>;
+		cs1_dq10_tx_de-skew = <8>;
+		cs1_dq11_rx_de-skew = <7>;
+		cs1_dq11_tx_de-skew = <7>;
+		cs1_dq12_rx_de-skew = <7>;
+		cs1_dq12_tx_de-skew = <8>;
+		cs1_dq13_rx_de-skew = <7>;
+		cs1_dq13_tx_de-skew = <7>;
+		cs1_dq14_rx_de-skew = <7>;
+		cs1_dq14_tx_de-skew = <8>;
+		cs1_dq15_rx_de-skew = <7>;
+		cs1_dq15_tx_de-skew = <7>;
+		cs1_dqs1_rx_de-skew = <7>;
+		cs1_dqs1p_tx_de-skew = <9>;
+		cs1_dqs1n_tx_de-skew = <9>;
+
+		cs1_dm2_rx_de-skew = <7>;
+		cs1_dm2_tx_de-skew = <8>;
+		cs1_dq16_rx_de-skew = <7>;
+		cs1_dq16_tx_de-skew = <8>;
+		cs1_dq17_rx_de-skew = <7>;
+		cs1_dq17_tx_de-skew = <8>;
+		cs1_dq18_rx_de-skew = <7>;
+		cs1_dq18_tx_de-skew = <8>;
+		cs1_dq19_rx_de-skew = <7>;
+		cs1_dq19_tx_de-skew = <8>;
+		cs1_dq20_rx_de-skew = <7>;
+		cs1_dq20_tx_de-skew = <8>;
+		cs1_dq21_rx_de-skew = <7>;
+		cs1_dq21_tx_de-skew = <8>;
+		cs1_dq22_rx_de-skew = <7>;
+		cs1_dq22_tx_de-skew = <8>;
+		cs1_dq23_rx_de-skew = <7>;
+		cs1_dq23_tx_de-skew = <8>;
+		cs1_dqs2_rx_de-skew = <6>;
+		cs1_dqs2p_tx_de-skew = <9>;
+		cs1_dqs2n_tx_de-skew = <9>;
+
+		cs1_dm3_rx_de-skew = <7>;
+		cs1_dm3_tx_de-skew = <7>;
+		cs1_dq24_rx_de-skew = <7>;
+		cs1_dq24_tx_de-skew = <8>;
+		cs1_dq25_rx_de-skew = <7>;
+		cs1_dq25_tx_de-skew = <7>;
+		cs1_dq26_rx_de-skew = <7>;
+		cs1_dq26_tx_de-skew = <7>;
+		cs1_dq27_rx_de-skew = <7>;
+		cs1_dq27_tx_de-skew = <7>;
+		cs1_dq28_rx_de-skew = <7>;
+		cs1_dq28_tx_de-skew = <7>;
+		cs1_dq29_rx_de-skew = <7>;
+		cs1_dq29_tx_de-skew = <7>;
+		cs1_dq30_rx_de-skew = <7>;
+		cs1_dq30_tx_de-skew = <7>;
+		cs1_dq31_rx_de-skew = <7>;
+		cs1_dq31_tx_de-skew = <7>;
+		cs1_dqs3_rx_de-skew = <7>;
+		cs1_dqs3p_tx_de-skew = <9>;
+		cs1_dqs3n_tx_de-skew = <9>;
+	};
+};


### PR DESCRIPTION
```
root@beikeyun-p1:~# cat /sys/class/devfreq/dmc/cur_freq
924000000
root@beikeyun-p1:~# ./tinymembench
tinymembench v0.4.9 (simple benchmark for memory throughput and latency)

==========================================================================
== Memory bandwidth tests                                               ==
==                                                                      ==
== Note 1: 1MB = 1000000 bytes                                          ==
== Note 2: Results for 'copy' tests show how many bytes can be          ==
==         copied per second (adding together read and writen           ==
==         bytes would have provided twice higher numbers)              ==
== Note 3: 2-pass copy means that we are using a small temporary buffer ==
==         to first fetch data into it, and only then write it to the   ==
==         destination (source -> L1 cache, L1 cache -> destination)    ==
== Note 4: If sample standard deviation exceeds 0.1%, it is shown in    ==
==         brackets                                                     ==
==========================================================================

 C copy backwards                                     :   1830.6 MB/s (1.2%)
 C copy backwards (32 byte blocks)                    :   1864.0 MB/s (1.4%)
 C copy backwards (64 byte blocks)                    :   1798.0 MB/s (1.4%)
 C copy                                               :   1923.9 MB/s (0.2%)
 C copy prefetched (32 bytes step)                    :   1670.3 MB/s
 C copy prefetched (64 bytes step)                    :   1942.8 MB/s
 C 2-pass copy                                        :   1979.6 MB/s
 C 2-pass copy prefetched (32 bytes step)             :   1430.5 MB/s
 C 2-pass copy prefetched (64 bytes step)             :   1409.2 MB/s
 C fill                                               :   7058.1 MB/s
 C fill (shuffle within 16 byte blocks)               :   7057.0 MB/s
 C fill (shuffle within 32 byte blocks)               :   7057.5 MB/s
 C fill (shuffle within 64 byte blocks)               :   7058.2 MB/s
 ---
 standard memcpy                                      :   1807.5 MB/s
 standard memset                                      :   7067.6 MB/s
 ---
 NEON LDP/STP copy                                    :   1984.1 MB/s
 NEON LDP/STP copy pldl2strm (32 bytes step)          :   1616.8 MB/s (1.1%)
 NEON LDP/STP copy pldl2strm (64 bytes step)          :   1860.7 MB/s (0.7%)
 NEON LDP/STP copy pldl1keep (32 bytes step)          :   2163.9 MB/s (0.1%)
 NEON LDP/STP copy pldl1keep (64 bytes step)          :   2189.6 MB/s (0.1%)
 NEON LD1/ST1 copy                                    :   1958.5 MB/s (0.4%)
 NEON STP fill                                        :   7066.0 MB/s (1.4%)
 NEON STNP fill                                       :   4483.2 MB/s (1.3%)
 ARM LDP/STP copy                                     :   1989.1 MB/s (0.5%)
 ARM STP fill                                         :   7063.4 MB/s (1.4%)
 ARM STNP fill                                        :   4429.6 MB/s (0.9%)
.
.
.
```