### PR TITLE
remove: fix use-after-free at btmtksdio_recv_event

### DIFF
--- a/drivers/bluetooth/btmtksdio.c
+++ b/drivers/bluetooth/btmtksdio.c
@@ -331,7 +331,6 @@ static int btmtksdio_recv_event(struct hci_dev *hdev, struct sk_buff *skb)
 {
 	struct btmtksdio_dev *bdev = hci_get_drvdata(hdev);
 	struct hci_event_hdr *hdr = (void *)skb->data;
-	u8 evt = hdr->evt;
 	int err;
 
 	/* Fix up the vendor event id with 0xff for vendor specific instead
@@ -356,7 +355,7 @@ static int btmtksdio_recv_event(struct hci_dev *hdev, struct sk_buff *skb)
 	if (err < 0)
 		goto err_free_skb;
 
-	if (evt == HCI_EV_VENDOR) {
+	if (hdr->evt == HCI_EV_VENDOR) {
 		if (test_and_clear_bit(BTMTKSDIO_TX_WAIT_VND_EVT,
 				       &bdev->tx_state)) {
 			/* Barrier to sync with other CPUs */


### PR DESCRIPTION
此修复会导致 mt7661rsn(mt7663s) 驱动后蓝牙MAC全部为00，且蓝牙不可用。
移除此修复后，蓝牙可以正常工作。仅mt7663s测试有效，没环境测试mt7668s(此修复包含mt7663s与mt7668s)。

注: 在6.1.y内核中此修复不会导致蓝牙异常。