### PR TITLE
Support for HK1 BOX blue led (not LED display)

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
@@ -88,6 +88,21 @@
 		dev_name = "openvfd";
 		status = "okay";
 	};
+	
+	leds {
+		compatible = "gpio-leds";
+		status = "okay";
+		sys_led {
+			label = "sys_led";
+			gpios = <0x75 0x0b 0x00>;
+			default-state = "on";
+			linux,default-trigger = "default-on";
+		};
+	};
+};
+
+&gpio_ao {
+	phandle = <117>;
 };
 
 &vddcpu {


### PR DESCRIPTION
根据 [ophub/amlogic-s9xxx-armbian 中 issue ](https://github.com/ophub/amlogic-s9xxx-armbian/issues/414) 说明，开启HK1BOX的蓝色指示灯，不是LED显示屏。