### PR TITLE
arm64: dts: amlogic: add OneThing Cloud OES

### DIFF
--- a/arch/arm64/boot/dts/amlogic/Makefile
+++ b/arch/arm64/boot/dts/amlogic/Makefile
@@ -22,6 +22,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro-rev_a.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro-rev_a-oc.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-ali-ct2000.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
+dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-onethingcloud-oes.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb

--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-onethingcloud-oes.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-onethingcloud-oes.dts
@@ -1,0 +1,380 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2019 BayLibre, SAS
+ * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
+ * Copyright (c) 2025 retro98boy <retro98boy@qq.com>
+ */
+
+/dts-v1/;
+
+#include "meson-g12b-a311d.dtsi"
+#include <dt-bindings/input/input.h>
+#include <dt-bindings/gpio/meson-g12a-gpio.h>
+#include <dt-bindings/leds/common.h>
+
+/ {
+	compatible = "onethingcloud,oes", "amlogic,a311d", "amlogic,g12b";
+	model = "OneThing Cloud OES";
+
+	aliases {
+		serial0 = &uart_AO;
+		ethernet0 = &ethmac;
+		rtc99 = &vrtc;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	memory@0 {
+		device_type = "memory";
+		reg = <0x0 0x0 0x0 0xee6b2800>; /* 4GB */
+	};
+
+	fan0: gpio-fan {
+		compatible = "gpio-fan";
+		gpio-fan,speed-map = <0 0 3000 1>;
+		gpios = <&gpio GPIOC_4 GPIO_ACTIVE_HIGH>;
+		#cooling-cells = <2>;
+	};
+
+	gpio-keys-polled {
+		compatible = "gpio-keys-polled";
+		poll-interval = <100>;
+
+		pwr-btn {
+			label = "pwr-btn";
+			linux,code = <KEY_POWER>;
+			gpios = <&gpio GPIOH_4 GPIO_ACTIVE_LOW>;
+		};
+
+		rec-btn {
+			label = "rec-btn";
+			linux,code = <KEY_VENDOR>;
+			gpios = <&gpio GPIOA_0 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	gpio-leds {
+		compatible = "gpio-leds";
+
+		/*
+		 * The circuit design of this device, in its default state (when powered on but the SoC has not started),
+		 * has the red power LED on and the green power LED off.
+		 * Therefore, by simply turning off the red power LED and turning on the green power LED in the kernel,
+		 * it can indicate that the kernel has started.
+		 */
+		pwr-led-green {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_LOW>;
+			default-state = "on";
+		};
+
+		pwr-led-red {
+			function = LED_FUNCTION_POWER;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio GPIOA_5 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+		};
+
+		/* https://stackoverflow.com/questions/63484352/device-tree-config-for-netdev-trigger-sources-to-control-led-based-on-link-statu */
+		/* cat /sys/class/leds/green\:lan/trigger */
+		lan-led-green {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio GPIOC_3 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			linux,default-trigger = "0.0:00:link";
+		};
+
+		lan-led-red {
+			function = LED_FUNCTION_LAN;
+			color = <LED_COLOR_ID_RED>;
+			gpios = <&gpio GPIOA_4 GPIO_ACTIVE_HIGH>; /* In fact, a low level lights up the LED. */
+			/*
+			 * The default state is off (low level), meaning that after the SoC starts,
+			 * if no network cable is connected, the red LED lights up by default.
+			 */
+			default-state = "off";
+			linux,default-trigger = "0.0:00:link";
+		};
+
+		/*
+		 * Currently, it is not possible to bind each LED's trigger to a specific SATA hard drive in the kernel.
+		 * Instead, in user space, SATA hard drives can be detected and LEDs controlled through udev rules or scripts.
+		 */
+		sata1-led-green {
+			function = LED_FUNCTION_DISK;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio GPIOA_14 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			/* linux,default-trigger = "ata1"; */
+		};
+
+		sata2-led-green {
+			function = LED_FUNCTION_DISK;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio GPIOA_15 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			/* linux,default-trigger = "ata2"; */
+		};
+
+		sata3-led-green {
+			function = LED_FUNCTION_DISK;
+			color = <LED_COLOR_ID_GREEN>;
+			gpios = <&gpio GPIOC_0 GPIO_ACTIVE_LOW>;
+			default-state = "off";
+			/* linux,default-trigger = "ata3"; */
+		};
+	};
+
+	emmc_pwrseq: emmc-pwrseq {
+		compatible = "mmc-pwrseq-emmc";
+		reset-gpios = <&gpio BOOT_12 GPIO_ACTIVE_LOW>;
+	};
+
+	dc_in: regulator-dc-in {
+		compatible = "regulator-fixed";
+		regulator-name = "dc_in";
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	vddao_1v8: regulator-vddao-1v8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vddao_1v8";
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	vddcpu_a: regulator-vddcpu-a {
+		compatible = "pwm-regulator";
+		regulator-name = "VDDCPU_A";
+		regulator-min-microvolt = <690000>;
+		regulator-max-microvolt = <1050000>;
+		pwm-supply = <&dc_in>;
+		pwms = <&pwm_ab 0 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vddcpu_b: regulator-vddcpu-b {
+		compatible = "pwm-regulator";
+		regulator-name = "VDDCPU_B";
+		regulator-min-microvolt = <690000>;
+		regulator-max-microvolt = <1050000>;
+		pwm-supply = <&dc_in>;
+		pwms = <&pwm_AO_cd 1 1250 0>;
+		pwm-dutycycle-range = <100 0>;
+		regulator-boot-on;
+		regulator-always-on;
+	};
+
+	vsys_3v3: regulator-vsys-3v3 {
+		compatible = "regulator-fixed";
+		regulator-name = "vsys_3v3";
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	usb_pwr: regulator-usb-pwr {
+		compatible = "regulator-fixed";
+		regulator-name = "usb_pwr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	regulator-sata1-pwr {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOC_6 GPIO_ACTIVE_HIGH>;
+		regulator-name = "sata1_pwr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	regulator-sata2-pwr {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio GPIOC_5 GPIO_ACTIVE_HIGH>;
+		regulator-name = "sata2_pwr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+
+	regulator-sata3-pwr {
+		compatible = "regulator-fixed";
+		enable-active-high;
+		gpio = <&gpio_ao GPIOAO_3 GPIO_ACTIVE_HIGH>;
+		regulator-name = "sata3_pwr";
+		regulator-always-on;
+		regulator-boot-on;
+		vin-supply = <&dc_in>;
+	};
+};
+
+&cpu0 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu1 {
+	cpu-supply = <&vddcpu_b>;
+	operating-points-v2 = <&cpu_opp_table_0>;
+	clocks = <&clkc CLKID_CPU_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu100 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu101 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu102 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu103 {
+	cpu-supply = <&vddcpu_a>;
+	operating-points-v2 = <&cpub_opp_table_1>;
+	clocks = <&clkc CLKID_CPUB_CLK>;
+	clock-latency = <50000>;
+};
+
+&cpu_thermal {
+	trips {
+		cpu_active: cpu-active {
+			temperature = <60000>; /* millicelsius */
+			hysteresis = <5000>; /* millicelsius */
+			type = "active";
+		};
+	};
+
+	cooling-maps {
+		map2 {
+			trip = <&cpu_active>;
+			cooling-device = <&fan0 THERMAL_NO_LIMIT THERMAL_NO_LIMIT>;
+		};
+	};
+};
+
+&ethmac {
+	pinctrl-0 = <&eth_pins>, <&eth_rgmii_pins>;
+	pinctrl-names = "default";
+	status = "okay";
+	phy-mode = "rgmii";
+	phy-handle = <&rtl8211f>;
+	amlogic,tx-delay-ns = <2>;
+};
+
+&ext_mdio {
+	rtl8211f: rtl8211f@0 {
+		reg = <0>;
+		max-speed = <1000>;
+
+		reset-assert-us = <10000>;
+		reset-deassert-us = <80000>;
+		reset-gpios = <&gpio GPIOZ_15 (GPIO_ACTIVE_LOW | GPIO_OPEN_DRAIN)>;
+
+		interrupt-parent = <&gpio_intc>;
+		/* MAC_INTR on GPIOZ_14 */
+		/* interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; */
+		interrupts = <26 IRQ_TYPE_LEVEL_LOW>; /* tested by voltmeter */
+	};
+};
+
+/*
+&npu {
+	status = "okay";
+};
+*/
+
+&pcie {
+	status = "okay";
+	reset-gpios = <&gpio GPIOC_1 GPIO_ACTIVE_LOW>; /* tested by voltmeter */
+};
+
+&pwm_ab {
+	status = "okay";
+	pinctrl-0 = <&pwm_a_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin0";
+};
+
+&pwm_AO_cd {
+	pinctrl-0 = <&pwm_ao_d_e_pins>;
+	pinctrl-names = "default";
+	clocks = <&xtal>;
+	clock-names = "clkin1";
+	status = "okay";
+};
+
+&sd_emmc_c {
+	status = "okay";
+	pinctrl-0 = <&emmc_ctrl_pins>, <&emmc_data_8b_pins>, <&emmc_ds_pins>;
+	pinctrl-1 = <&emmc_clk_gate_pins>;
+	pinctrl-names = "default", "clk-gate";
+
+	max-frequency = <200000000>;
+	bus-width = <8>;
+	cap-mmc-highspeed;
+	mmc-ddr-1_8v;
+	mmc-hs200-1_8v;
+	non-removable;
+
+	mmc-pwrseq = <&emmc_pwrseq>;
+	vmmc-supply = <&vsys_3v3>;
+	vqmmc-supply = <&vddao_1v8>;
+};
+
+&uart_AO {
+	status = "okay";
+	pinctrl-0 = <&uart_ao_a_pins>;
+	pinctrl-names = "default";
+};
+
+&usb2_phy0 {
+	phy-supply = <&usb_pwr>;
+};
+
+&usb2_phy1 {
+	phy-supply = <&usb_pwr>;
+};
+
+&usb3_pcie_phy {
+	phy-supply = <&usb_pwr>;
+};
+
+&usb {
+	status = "okay";
+	dr_mode = "host";
+	phys = <&usb2_phy0>, <&usb2_phy1>;
+	phy-names = "usb2-phy0", "usb2-phy1";
+};


### PR DESCRIPTION
| Component             | Status                     |
|-----------------------|----------------------------|
| GBE                   | Working                    |
| GPIO Fan              | Working                    |
| eMMC                  | Working                    |
| USB                   | Working                    |
| GPIO Button           | Working                    |
| GPIO LED              | Working                    |
| SATA                  | Working                    |

如网上所说，目前在6.x.y内核，AHCI probe failed，所以暂时只能使用5.15.y内核才能驱动ASM1064 SATA Disk

目前无法在内核中将三个SATA LED绑定到三个SATA DIsk的活动，所以只能在用户层通过udev规则或者脚本实现检测Disk并操作LED

手动点亮LED的命令：`echo 1 > /sys/class/leds/green\:disk_2/brightness`

5.x.y内核暂时不存在etnaviv驱动和npu节点，所以暂时注释，可以在6.x.y下取消注释