### PR TITLE
adapt RGMII parameters of different versions of OES

### DIFF
--- a/arch/arm64/boot/dts/amlogic/Makefile
+++ b/arch/arm64/boot/dts/amlogic/Makefile
@@ -23,6 +23,7 @@ dtb-$(CONFIG_ARCH_MESON) += meson-g12b-gtking-pro-rev_a-oc.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-ali-ct2000.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-khadas-vim3.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-onethingcloud-oes.dtb
+dtb-$(CONFIG_ARCH_MESON) += meson-g12b-a311d-onethingcloud-oes-rgmii-rx-delay-3000ps.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-s922x-khadas-vim3.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2.dtb
 dtb-$(CONFIG_ARCH_MESON) += meson-g12b-odroid-n2-plus.dtb

--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-onethingcloud-oes-rgmii-rx-delay-3000ps.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-onethingcloud-oes-rgmii-rx-delay-3000ps.dts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
+/*
+ * Copyright (c) 2019 BayLibre, SAS
+ * Author: Neil Armstrong <narmstrong@baylibre.com>
+ * Copyright (c) 2019 Christian Hewitt <christianshewitt@gmail.com>
+ * Copyright (c) 2025 retro98boy <retro98boy@qq.com>
+ */
+
+/dts-v1/;
+
+#include "meson-g12b-a311d-onethingcloud-oes.dts"
+
+&ethmac {
+	phy-mode = "rgmii-rxid";
+	/* rtl8211f 2ns + MAC 1000ps */
+	rx-internal-delay-ps = <1000>;
+	/* keep MAC rx delay when in rgmii-rxid mode */
+	amlogic,keep-rx-internal-delay;
+	amlogic,invert-rxclk;
+};

--- a/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac-meson8b.c
@@ -29,6 +29,8 @@
 #define PRG_ETH0_EXT_RGMII_MODE		1
 #define PRG_ETH0_EXT_RMII_MODE		4
 
+#define PRG_ETH0_INVERT_RXCLK		BIT(3)
+
 /* mux to choose between fclk_div2 (bit unset) and mpll2 (bit set) */
 #define PRG_ETH0_CLK_M250_SEL_MASK	GENMASK(4, 4)
 
@@ -94,6 +96,8 @@ struct meson8b_dwmac {
 	struct clk			*rgmii_tx_clk;
 	u32				tx_delay_ns;
 	u32				rx_delay_ps;
+	bool				keep_rx_delay;
+	bool				invert_rxclk;
 	struct clk			*timing_adj_clk;
 };
 
@@ -299,7 +303,8 @@ static int meson8b_init_rgmii_delays(struct meson8b_dwmac *dwmac)
 		break;
 	case PHY_INTERFACE_MODE_RGMII_RXID:
 		delay_config = tx_dly_config;
-		cfg_rxclk_dly = 0;
+		if(!dwmac->keep_rx_delay)
+			cfg_rxclk_dly = 0;
 		break;
 	case PHY_INTERFACE_MODE_RGMII_TXID:
 		delay_config = rx_adj_config;
@@ -307,7 +312,8 @@ static int meson8b_init_rgmii_delays(struct meson8b_dwmac *dwmac)
 	case PHY_INTERFACE_MODE_RGMII_ID:
 	case PHY_INTERFACE_MODE_RMII:
 		delay_config = 0;
-		cfg_rxclk_dly = 0;
+		if(!dwmac->keep_rx_delay)
+			cfg_rxclk_dly = 0;
 		break;
 	default:
 		dev_err(dwmac->dev, "unsupported phy-mode %s\n",
@@ -336,6 +342,11 @@ static int meson8b_init_rgmii_delays(struct meson8b_dwmac *dwmac)
 				PRG_ETH0_ADJ_ENABLE | PRG_ETH0_ADJ_SETUP |
 				PRG_ETH0_ADJ_DELAY | PRG_ETH0_ADJ_SKEW,
 				delay_config);
+
+	if(dwmac->invert_rxclk)
+		meson8b_dwmac_mask_bits(dwmac, PRG_ETH0,
+					PRG_ETH0_INVERT_RXCLK,
+					PRG_ETH0_INVERT_RXCLK);
 
 	meson8b_dwmac_mask_bits(dwmac, PRG_ETH1, PRG_ETH1_CFG_RXCLK_DLY,
 				cfg_rxclk_dly);
@@ -455,6 +466,16 @@ static int meson8b_dwmac_probe(struct platform_device *pdev)
 			goto err_remove_config_dt;
 		}
 	}
+
+	/*
+	 * Some boards need to enable the internal RX delay of the PHY
+	 * while simultaneously enabling the internal RX delay of the MAC,
+	 * as implemented in the Amlogic BSP kernel.
+	 */
+	dwmac->keep_rx_delay = of_property_read_bool(pdev->dev.of_node,
+		"amlogic,keep-rx-internal-delay");
+
+	dwmac->invert_rxclk = of_property_read_bool(pdev->dev.of_node, "amlogic,invert-rxclk");
 
 	dwmac->timing_adj_clk = devm_clk_get_optional(dwmac->dev,
 						      "timing-adjustment");


### PR DESCRIPTION
OES设备可能存在不同版本，即使PHY都是rtl8211f，RGMII delay的参数也不能通用。不正确的RGMII rx delay会导致GBE接收带宽低甚至丢包

通过修改MAC驱动增加两个选项，可以很方便的把官方系统中的delay配置移植到主线内核

该提交还新增了一个dts，适用于auto_cali_idx为0x25版本的OES。该dts用于示例，如果该dts还是不能解决部分OES的GBE接收带宽问题，可以参考[此处](https://github.com/retro98boy/onethingcloud-oes-linux?tab=readme-ov-file#%E4%B8%8D%E5%90%8C%E7%89%88%E6%9C%ACoes%E7%9A%84gbe%E9%97%AE%E9%A2%98)自行调试/修改dts