### PR TITLE
arm64: amlogic: dts: Add LED configuration to match official status

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-onethingcloud-oes.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-onethingcloud-oes.dts
@@ -306,6 +306,8 @@
 		/* MAC_INTR on GPIOZ_14 */
 		/* interrupts = <IRQID_GPIOZ_14 IRQ_TYPE_LEVEL_LOW>; */
 		interrupts = <26 IRQ_TYPE_LEVEL_LOW>; /* tested by voltmeter */
+
+		realtek,led-data = <0xC160>;
 	};
 };
 


### PR DESCRIPTION
Set realtek,led-data=0xC160 to enable:
- Green LED when 1000/100Mbps link is up
- Blinking orange LED on link activity